### PR TITLE
Update URL Of Shared Frontend Package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,21 +10,22 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "^4.7.0",
-        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz"
+        "govuk-frontend": "^4.9.0",
+        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz"
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
     },
     "node_modules/govwifi-shared-frontend": {
       "version": "0.6.10",
-      "resolved": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz",
+      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz",
       "integrity": "sha512-cCXufreBrhQXxhR/TSTGqnYqbhBEpfXXJ1iHJqmBvzE3KSm7RP5WgybE8IjyKU93kEtua+xQ6iaHmtRlcW7E5g==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,17 +5,17 @@
   "description": "GovWifi tech docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alphagov/govwifi-tech-docs.git"
+    "url": "git+https://github.com/GovWifi/govwifi-tech-docs.git"
   },
   "author": "Government Digital Service developers",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alphagov/govwifi-tech-docs/issues"
+    "url": "https://github.com/GovWifi/govwifi-tech-docs/issues"
   },
-  "homepage": "https://github.com/alphagov/govwifi-tech-docs#readme",
+  "homepage": "https://github.com/GovWifi/govwifi-tech-docs#readme",
   "dependencies": {
-    "govuk-frontend": "^4.7.0",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz"
+    "govuk-frontend": "^4.9.0",
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What
Update URL Of Shared Frontend Package

### Why
We are migrating all of these packages to a dedicated GovWifi github organisation. This is due to the GDS/DSIT split.

### Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1851