### PR TITLE
chore: [GW-2294] Update Shared Library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^5.10.2",
-        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.11/govwifi-shared-frontend-0.6.11.tgz"
+        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.13/govwifi-shared-frontend-0.6.13.tgz"
       }
     },
     "node_modules/govuk-frontend": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/govwifi-shared-frontend": {
-      "version": "0.6.11",
-      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.11/govwifi-shared-frontend-0.6.11.tgz",
-      "integrity": "sha512-l4Whm6sETTVc+a+AL3zEqPXU+XvvcYsd4bOTWjPw/4XWVB1FX/RiTaq70bgX+fSa9eNVYc02ufs9WHakFcMKtw==",
+      "version": "0.6.13",
+      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.13/govwifi-shared-frontend-0.6.13.tgz",
+      "integrity": "sha512-PWZGe+Gq/+za1N69lAy6Z6s0MbwwB2657vTeZ8nLcz2sj38RD/d0MndrkTNf5qSYAEkzJvb/+hi9AjKN24PvSA==",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/GovWifi/govwifi-tech-docs#readme",
   "dependencies": {
     "govuk-frontend": "^5.10.2",
-    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.11/govwifi-shared-frontend-0.6.11.tgz"
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.13/govwifi-shared-frontend-0.6.13.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What

Update the shared frontend library

### Why

To keep it up to date with dependabot changes.

Link to JIRA card (if applicable):
[GW-2294](https://technologyprogramme.atlassian.net/browse/GW-2294)
