### PR TITLE
fix: [GW-2389] update middleman to 4.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,11 @@ gem 'wdm', '~> 0.1.1', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs', '~> 4.2.0'
+# pinned to 4.2.0 due to higher versions pinning middleman to 4.5.1
+gem 'govuk_tech_docs', '4.2.0'
 
 # Middleman Gems
-# Pinned to 4.5.1 due to this bug https://github.com/middleman/middleman/issues/2818
-gem 'middleman', '4.5.1'
+gem 'middleman', '4.6.2'
 
 # required since ruby > 3.4
 gem 'base64'
@@ -22,4 +22,7 @@ gem 'benchmark'
 gem 'bigdecimal'
 gem 'mutex_m'
 gem 'rdoc'
-
+gem 'kramdown' ## replace redcarpet which breaks with middleman > 4.5.1
+gem 'tilt'
+## needed if sass-embedded gives a seg fault.
+gem 'google-protobuf', force_ruby_platform: true if RUBY_PLATFORM.include?('linux-musl')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
-    backports (3.25.1)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
@@ -42,7 +41,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     erb (5.0.1)
-    erubis (2.7.0)
+    erubi (1.13.1)
     eventmachine (1.2.7)
     execjs (2.10.0)
     fast_blank (1.0.1)
@@ -96,44 +95,44 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     memoist (0.16.2)
-    middleman (4.5.1)
-      coffee-script (~> 2.2)
-      haml (>= 4.0.5)
-      kramdown (>= 2.3.0)
-      middleman-cli (= 4.5.1)
-      middleman-core (= 4.5.1)
+    middleman (4.6.2)
+      middleman-cli (= 4.6.2)
+      middleman-core (= 4.6.2)
     middleman-autoprefixer (2.10.0)
       autoprefixer-rails (>= 9.1.4)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.5.1)
-      thor (>= 0.17.0, < 1.3.0)
+    middleman-cli (4.6.2)
+      thor (>= 0.17.0, < 2)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.5.1)
-      activesupport (>= 6.1, < 7.1)
+    middleman-core (4.6.2)
+      activesupport (>= 6.1)
       addressable (~> 2.4)
-      backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13, < 0.17)
+      coffee-script (~> 2.2)
+      contracts
       dotenv
-      erubis
+      erubi
       execjs (~> 2.0)
       fast_blank
       fastimage (~> 2.0)
+      haml (>= 4.0.5)
       hamster (~> 3.0)
-      hashie (~> 3.4)
-      i18n (~> 1.6.0)
+      hashie (>= 3.4, < 6.0)
+      i18n (>= 1.6, < 1.15)
+      kramdown (~> 2.4)
       listen (~> 3.0)
       memoist (~> 0.14)
       padrino-helpers (~> 0.15.0)
       parallel
-      rack (>= 1.4.5, < 3)
+      rack (>= 3)
+      rackup
       sassc (~> 2.0)
       servolux
-      tilt (~> 2.0.9)
+      tilt (~> 2.2)
       toml
-      uglifier (~> 3.0)
+      uglifier (>= 3, < 5)
       webrick
     middleman-livereload (3.4.7)
       em-websocket (~> 0.5.1)
@@ -182,9 +181,11 @@ GEM
       stringio
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.14)
+    rack (3.2.0)
     rack-livereload (0.3.17)
       rack
+    rackup (2.2.1)
+      rack (>= 3)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -226,7 +227,7 @@ GEM
     terser (1.2.5)
       execjs (>= 0.3.0, < 3)
     thor (1.2.2)
-    tilt (2.0.11)
+    tilt (2.6.1)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)
     tzinfo (2.0.6)
@@ -252,10 +253,13 @@ DEPENDENCIES
   base64
   benchmark
   bigdecimal
+  google-protobuf
   govuk_tech_docs (~> 4.2.0)
-  middleman (= 4.5.1)
+  kramdown
+  middleman (= 4.6.2)
   mutex_m
   rdoc
+  tilt
   tzinfo-data
   wdm (~> 0.1.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,8 +253,7 @@ DEPENDENCIES
   base64
   benchmark
   bigdecimal
-  google-protobuf
-  govuk_tech_docs (~> 4.2.0)
+  govuk_tech_docs (= 4.2.0)
   kramdown
   middleman (= 4.6.2)
   mutex_m

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 build: stop
-	docker-compose build
+	docker compose build
 
 serve: build
-	docker-compose run --service-ports app bundle exec middleman server
+	docker compose run --service-ports app bundle exec middleman server
 
 deploy: build
-	docker-compose run app sh -c "cf login -u ${CF_USER} -p ${CF_PASS} -a https://api.cloud.service.gov.uk -s production && cf push govwifi-tech-docs"
+	docker compose run app sh -c "cf login -u ${CF_USER} -p ${CF_PASS} -a https://api.cloud.service.gov.uk -s production && cf push govwifi-tech-docs"
 	$(MAKE) stop
 
 stop:
-	docker-compose kill
-	docker-compose rm -f
+	docker compose kill
+	docker compose rm -f
 
 .PHONY: build deploy stop

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,8 @@
 require 'govuk_tech_docs'
+require 'kramdown'
 
+GovukTechDocs.configure(self)
+set :markdown_engine, :kramdown
 set :relative_links, true
 
 configure :build do
@@ -9,8 +12,6 @@ configure :build do
     }
     activate :relative_assets
 end
-
-GovukTechDocs.configure(self)
 
 redirect "set_up/index.html", to: "/set_up.html"
 redirect "requirements/index.html", to: "/requirements.html"


### PR DESCRIPTION
### What
Update middleman to 4.6.2.
Not an easy job since we depend upon govuk-tech-docs which pins middleman to 4.5.1
Also MM 4.6.2 breaks the RedCarpet markdown renderer, so needed to replace with Kramdown, thanks Jos!

### Why
Security vulnerability with Thor used in Middleman.


### Link to Jira card (if applicable): 
[GW-2389](https://technologyprogramme.atlassian.net/browse/GW-2389)
